### PR TITLE
CDC-7: Updates Submodule

### DIFF
--- a/.github/workflows/check-submodule-pr-status.yml
+++ b/.github/workflows/check-submodule-pr-status.yml
@@ -119,7 +119,7 @@ jobs:
                 status = 'completed';
                 conclusion = 'success';
                 title = 'Submodule PR Closed';
-                summary = `✅ Submodule PR #${submodulePr.number} has been closed. This PR can now be merged.`;
+                summary = `✅ Submodule PR [#${submodulePr.number}](${submodulePr.html_url}) has been closed. This PR can now be merged.`;
                 
                 // Update PR comment
                 const { data: comments } = await github.rest.issues.listComments({
@@ -165,7 +165,7 @@ jobs:
               } else {
                 status = 'in_progress';
                 title = 'Waiting for Submodule PR';
-                summary = `⏳ Waiting for submodule PR #${submodulePr.number} to be closed before allowing merge.`;
+                summary = `⏳ Waiting for submodule PR [#${submodulePr.number}](${submodulePr.html_url}) to be closed before allowing merge.`;
               }
               
               // Create or update check run

--- a/.github/workflows/pr-link-submodule.yml
+++ b/.github/workflows/pr-link-submodule.yml
@@ -209,6 +209,7 @@ jobs:
               title = 'Submodule PR Linked';
               summary = `Linked to submodule PR: ${prUrl}\n\nWaiting for submodule PR to be closed before allowing merge.`;
             }
+            // ^ instead of this. I want to not check if it exists and is closed. I want to check if it exists, is open, and is approved
             
             const checkRun = {
               owner: context.repo.owner,

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ TODO
   - [ ] what about multiple submodules?
   - [x] fix comment formatting
   - [ ] scalability? is polling a good option every 5 minutes?
+  - [ ] create PR drafts automatically
+  - [ ] change base PR check for submodule PRs.
+      - Right now it is: check submodule PR exists and is closed
+      - New: check is submodule PR exists, is opened, and is approved


### PR DESCRIPTION
This is just a test PR to see the current state of things.

Current checks it needs
1. 1 approval
2.  No Submodule changes. or Submodule PR and closed for those changes
3.  No conflicts

Current developer flow
1. open PR
4. run checks to see if it finds submodule PR (it shouldnt)
5. open submodule PR and rerun checks (it should find submodule PR)
6. close submodule PR (no merge)
7. wait for update status (this should be fixed from timer to a polling method. idk if this is scalable as is or clunky)
8. see this PR is ready to merge

Problems and Kinks to work out
1. submodule conflicts. not sure how this handles these issues yet I have not tested in depth
2. multiple submodules
3. There is an action to merge everything but it does not work yet. need to fix
4. How to close a PR and not merge it. if you just willy nilly close it and dont review it the check will pass. not perfect. aka developer can lie and just close it